### PR TITLE
Adding Code to Capture/Profile Statistics for LLM Calls to Generate Code

### DIFF
--- a/src/palimpzest/solver/solver.py
+++ b/src/palimpzest/solver/solver.py
@@ -300,7 +300,7 @@ class Solver:
                     ], outputs=[
                         {'name': field_name, 'type': 'str', 'desc': f.desc}
                     ])
-                    codes = getConversionCodes(inputSchema, {field_name: f}, conversionDesc, config, model, api, example_inputs=inputs)
+                    codes, field_codegen_stats = getConversionCodes(inputSchema, {field_name: f}, conversionDesc, config, model, api, example_inputs=inputs)
                     answers, field_stats = list(), defaultdict(float)
                     for code in codes:
                         answer, code_stats = exec_codegen(api, code, inputs)
@@ -314,7 +314,7 @@ class Solver:
                     if config.get('codegen_logging', default=False):
                         majority_answer += " (code extracted)"
                     setattr(dr, field_name, majority_answer)
-                    stats[f"{field_name}"] = field_stats
+                    stats[f"{field_name}"] = {"conversion_stats": field_stats, "codegen_stats": field_codegen_stats}
 
                 # if profiling, set record's stats for the given op_id
                 if Profiler.profiling_on():

--- a/src/palimpzest/tools/dspysearch.py
+++ b/src/palimpzest/tools/dspysearch.py
@@ -193,7 +193,7 @@ def exec_codegen(api, code, inputs, verbose=False):
     
     stats = {}
     if Profiler.profiling_on():
-        stats['api_call_duration'] = end_time - start_time
+        stats['codegen_execution_duration'] = end_time - start_time
     
     if verbose:
         print(f"Code:\n{code}\nInputs:\n{inputs}\nResult:\n{response}\n")


### PR DESCRIPTION
Currently `dr._stats` in `_makeCodeGenTypeConversionFn()` only captures time spent executing generated code, but not time spent creating generated code. I've simply extended what Zui wrote to return the profiling statistics all the way back to the `dr._stats` dictionary.
