### PR TITLE
Add a new group by operator

### DIFF
--- a/src/palimpzest/datamanager/datamanager.py
+++ b/src/palimpzest/datamanager/datamanager.py
@@ -217,7 +217,6 @@ class DataDirectory(metaclass=DataDirectorySingletonMeta):
         """Return a cached result."""
         if not cacheId in self._cache:
             return None
-
         cachedResult = pickle.load(open(self._cache[cacheId], "rb"))
         def iterateOverCachedResult():
             for x in cachedResult:
@@ -251,7 +250,11 @@ class DataDirectory(metaclass=DataDirectorySingletonMeta):
     def closeCache(self, cacheId):
         """Close the cache."""
         filename = self._dir + "/data/cache/" + cacheId + ".cached"
-        pickle.dump(self._tempCache[cacheId], open(filename, "wb"))
+        try:
+            pickle.dump(self._tempCache[cacheId], open(filename, "wb"))
+        except pickle.PicklingError:
+            print("Warning: Failed to save cache due to pickling error")
+            os.remove(filename)
         del self._tempCache[cacheId]
         self._cache[cacheId] = filename
 

--- a/src/palimpzest/elements/__init__.py
+++ b/src/palimpzest/elements/__init__.py
@@ -3,3 +3,4 @@ from .filters import *
 from .aggregatefunction import *
 from .records import *
 from .functions import *
+from .groupbysig import *

--- a/src/palimpzest/elements/elements.py
+++ b/src/palimpzest/elements/elements.py
@@ -205,6 +205,10 @@ class Any(Schema):
     def children(self) -> List[Schema]:
         return self._possibleSchemas
 
+class OperatorDerivedSchema(Schema):
+    """Schema defined by an operator, e.g., a join or a group by"""
+
+
 class File(Schema):
     """
     A File is defined by two Fields:

--- a/src/palimpzest/elements/groupbysig.py
+++ b/src/palimpzest/elements/groupbysig.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Any, Dict
-from palimpzest.elements import Field, OperatorDerivedSchema
+from palimpzest.elements import Field, OperatorDerivedSchema, Schema
 
 #signature for a group by aggregate that applies
 # group and aggregation to an input tuple
@@ -10,6 +10,15 @@ class GroupBySig:
         self.aggFields = aggFields
         self.aggFuncs = aggFuncs
 
+    def validateSchema(self, inputSchema: Schema) -> tuple[bool, str]:
+        for f in self.gbyFields:
+            if not hasattr(inputSchema, f):
+                return (False, "Supplied schema has no field " + f)
+        for f in self.aggFields:
+            if not hasattr(inputSchema, f):
+                return (False, "Supplied schema has no field " + f)
+        return (True, None)
+    
     def serialize(a) -> Dict[str, Any]:
         out = {"groupByFields":a.gbyFields, "aggFuncs":a.aggFuncs, "aggFields": a.aggFields}
         return out

--- a/src/palimpzest/elements/groupbysig.py
+++ b/src/palimpzest/elements/groupbysig.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+from typing import Any, Dict
+from palimpzest.elements import Field, OperatorDerivedSchema
+
+#signature for a group by aggregate that applies
+# group and aggregation to an input tuple
+class GroupBySig:
+    def __init__(self, gbyFields: list[str], aggFuncs:list[str], aggFields:list[str]):
+        self.gbyFields = gbyFields 
+        self.aggFields = aggFields
+        self.aggFuncs = aggFuncs
+
+    def serialize(a) -> Dict[str, Any]:
+        out = {"groupByFields":a.gbyFields, "aggFuncs":a.aggFuncs, "aggFields": a.aggFields}
+        return out
+    
+    def deserialize(d) -> GroupBySig:
+        return GroupBySig(d["groupByFields"], d["aggFuncs"], d["aggFields"])
+    
+
+    def __str__(self) -> str:
+        return "GroupBy(" + repr(GroupBySig.serialize(self)) + ")"
+
+    def __hash__(self) -> int:
+        # custom hash function
+        return hash(repr(GroupBySig.serialize(self)))
+
+    def __eq__(self, other: GroupBySig) -> bool:
+        # __eq__ should be defined for consistency with __hash__
+        return isinstance(other, GroupBySig) and GroupBySig.serialize(self) == GroupBySig.serialize(other)
+    
+    def getAggFieldNames(self) -> list[str]:
+        ops = []
+        for i in range(0, len(self.aggFields)):
+            ops.append(self.aggFuncs[i] + "(" + self.aggFields[i] + ")")
+        return ops
+    
+    def outputSchema(self) -> OperatorDerivedSchema: 
+        #the output class varies depending on the group by, so here 
+        # we dynamically construct this output
+        s = type('CustomGroupBy', (OperatorDerivedSchema,), {})
+
+        for g in self.gbyFields:
+            f = Field(desc = g, required=True)
+            setattr(s, g, f)
+        ops = self.getAggFieldNames()
+        for op in ops:
+            f = Field(desc = op, required=True)
+            setattr(s, op, f)
+        return s

--- a/src/palimpzest/elements/records.py
+++ b/src/palimpzest/elements/records.py
@@ -35,6 +35,11 @@ class DataRecord:
 
         super().__setattr__(key, value)
 
+
+
+    def __getitem__(self, key):
+        return super().__getattr__(key)
+
     @property
     def schema(self):
         return self._schema

--- a/src/palimpzest/operators/operators.py
+++ b/src/palimpzest/operators/operators.py
@@ -396,6 +396,9 @@ class FilteredScan(LogicalOperator):
 class GroupByAggregate(LogicalOperator):
     def __init__(self, outputSchema: Schema, inputOp: LogicalOperator, gbySig: elements.GroupBySig, targetCacheId: str=None):
         super().__init__(outputSchema, inputOp.outputSchema)
+        (valid, error) = gbySig.validateSchema(inputOp.outputSchema)
+        if (not valid):
+            raise TypeError(error)
         self.inputOp = inputOp 
         self.gbySig = gbySig
         self.targetCacheId = targetCacheId

--- a/src/palimpzest/operators/operators.py
+++ b/src/palimpzest/operators/operators.py
@@ -15,6 +15,7 @@ from palimpzest.operators import (
     ParallelFilterCandidateOp,
     ParallelInduceFromCandidateOp,
     PhysicalOp,
+    ApplyGroupByOp
 )
 from palimpzest.sampler import Sampler
 
@@ -390,6 +391,24 @@ class FilteredScan(LogicalOperator):
             return ParallelFilterCandidateOp(self.outputSchema, self.inputOp._getPhysicalTree(strategy=strategy, model=model, shouldProfile=shouldProfile), self.filter, model=model, targetCacheId=self.targetCacheId, shouldProfile=shouldProfile)
         else:
             return FilterCandidateOp(self.outputSchema, self.inputOp._getPhysicalTree(strategy=strategy, model=model, shouldProfile=shouldProfile), self.filter, model=model, targetCacheId=self.targetCacheId, shouldProfile=shouldProfile)
+
+
+class GroupByAggregate(LogicalOperator):
+    def __init__(self, outputSchema: Schema, inputOp: LogicalOperator, gbySig: elements.GroupBySig, targetCacheId: str=None):
+        super().__init__(outputSchema, inputOp.outputSchema)
+        self.inputOp = inputOp 
+        self.gbySig = gbySig
+        self.targetCacheId = targetCacheId
+    def __str__(self):
+        descStr = "Grouping Fields:" 
+        return (f"GroupBy({elements.GroupBySig.serialize(self.gbySig)})")
+    
+    def dumpLogicalTree(self):
+        """Return the logical subtree rooted at this operator"""
+        return (self, self.inputOp.dumpLogicalTree())
+
+    def _getPhysicalTree(self, strategy: str=None, model: Model=None, shouldProfile: bool=False):
+        return ApplyGroupByOp(self.inputOp._getPhysicalTree(strategy=strategy, model=model, shouldProfile=shouldProfile), self.gbySig, targetCacheId=self.targetCacheId, shouldProfile=shouldProfile)
 
 
 class ApplyAggregateFunction(LogicalOperator):

--- a/src/palimpzest/operators/physical.py
+++ b/src/palimpzest/operators/physical.py
@@ -901,6 +901,8 @@ class ApplyGroupByOp(PhysicalOp):
                     #build group array
                     group = ()
                     for f in self.gbySig.gbyFields:
+                        if (not hasattr(r, f)):
+                            raise TypeError(f"ApplyGroupOp record missing expected field {f}")
                         group = group + (getattr(r,f),)
                     if group in aggState:
                         state = aggState[group]
@@ -910,6 +912,8 @@ class ApplyGroupByOp(PhysicalOp):
                             state.append(agg_init(fun))
                     for i in range(0,len(self.gbySig.aggFuncs)):
                         fun = self.gbySig.aggFuncs[i]
+                        if (not hasattr(r, self.gbySig.aggFields[i])):
+                            raise TypeError(f"ApplyGroupOp record missing expected field {self.gbySig.aggFields[i]}")
                         field = getattr(r, self.gbySig.aggFields[i])
                         state[i] = agg_merge(fun, state[i], field)
                     aggState[group] = state

--- a/tests/simpleDemo.py
+++ b/tests/simpleDemo.py
@@ -7,7 +7,7 @@ from PIL import Image
 
 
 from palimpzest.execution import Execution
-from palimpzest.elements import DataRecord
+from palimpzest.elements import DataRecord, GroupBySig
 
 import gradio as gr
 import numpy as np
@@ -132,6 +132,40 @@ def computeEnronStats(datasetId):
     subjectLineLengths = emails.convert(pz.Number, desc = "The number of words in the subject field")
     return subjectLineLengths
 
+def enronGbyPlan(datasetId):
+    emails = pz.Dataset(datasetId, schema=Email)
+    ops = ["count"]
+    fields = ["sender"]
+    groupbyfields = ["sender"]
+    gbyDesc = GroupBySig(groupbyfields, ops, fields)
+    groupedEmails = emails.groupby(gbyDesc)
+    return groupedEmails
+
+def enronCountPlan(datasetId):
+    emails = pz.Dataset(datasetId, schema=Email)
+    ops = ["count"]
+    fields = ["sender"]
+    groupbyfields = []
+    gbyDesc = GroupBySig(groupbyfields, ops, fields)
+    countEmails = emails.groupby(gbyDesc)
+    return countEmails
+
+def enronAverageCountPlan(datasetId):
+    emails = pz.Dataset(datasetId, schema=Email)
+    ops = ["count"]
+    fields = ["sender"]
+    groupbyfields = ["sender"]
+    gbyDesc = GroupBySig(groupbyfields, ops, fields)
+    groupedEmails = emails.groupby(gbyDesc)
+    ops = ["average"]
+    fields = ["count(sender)"]
+    groupbyfields = []
+    gbyDesc = GroupBySig(groupbyfields, ops, fields)
+    averageEmailsPerSender = groupedEmails.groupby(gbyDesc)
+
+    return averageEmailsPerSender
+
+
 class DogImage(pz.ImageFile):
     breed = pz.Field(desc="The breed of the dog", required = True)
 
@@ -140,6 +174,17 @@ def buildImagePlan(datasetId):
     filteredImages = images.filterByStr("The image contains one or more dogs")
     dogImages = filteredImages.convert(DogImage, desc = "Images of dogs")
     return dogImages
+
+def buildImageAggPlan(datasetId):
+    images = pz.Dataset(datasetId, schema=pz.ImageFile)
+    filteredImages = images.filterByStr("The image contains one or more dogs")
+    dogImages = filteredImages.convert(DogImage, desc = "Images of dogs")
+    ops = ["count"]
+    fields = ["breed"]
+    groupbyfields = ["breed"]
+    gbyDesc = GroupBySig(groupbyfields, ops, fields)
+    groupedDogImages = dogImages.groupby(gbyDesc)
+    return groupedDogImages
 
 
 def buildNestedStr(node, indent=0, buildStr=""):
@@ -290,6 +335,29 @@ if __name__ == "__main__":
         print("----------")
         print()
         printTable(records, cols=["sender", "subject"], gradio=True, plan=physicalTree)
+    elif task == "enronGby":
+        rootSet = enronGbyPlan(datasetid)
+        physicalTree = emitDataset(rootSet, policy, title="Enron email counts", verbose=args.verbose)
+        records = [r for r in physicalTree]
+        print("----------")
+        print()
+        printTable(records, cols=["sender", "count(sender)"], gradio=True, plan=physicalTree)
+    elif task == "enronCount":
+        rootSet = enronCountPlan(datasetid)
+        physicalTree = emitDataset(rootSet, policy, title="Enron email counts", verbose=args.verbose)
+        records = [r for r in physicalTree]
+        print("----------")
+        print()
+        printTable(records, cols=["count(sender)"], gradio=True, plan=physicalTree)
+    elif task == "enronAvgCount":
+        rootSet = enronAverageCountPlan(datasetid)
+        physicalTree = emitDataset(rootSet, policy, title="Enron email counts", verbose=args.verbose)
+        records = [r for r in physicalTree]
+        print("----------")
+        print()
+        printTable(records, cols=["average(count(sender))"], gradio=True, plan=physicalTree)
+
+
 
     elif task == "enronoptimize":
         rootSet = buildEnronPlan(datasetid)
@@ -372,6 +440,11 @@ if __name__ == "__main__":
         print()
         printTable(records, gradio=True, plan=physicalTree)
 
+    elif task =="gbyImage":
+        rootSet = buildImageAggPlan(datasetid)
+        physicalTree = emitDataset(rootSet, policy, title="Dogs", verbose=args.verbose)
+        for r in physicalTree:
+            print(r)
 
     elif task == "image":
         print("Starting image task")

--- a/tests/simpleDemo.py
+++ b/tests/simpleDemo.py
@@ -137,7 +137,7 @@ def enronGbyPlan(datasetId):
     ops = ["count"]
     fields = ["sender"]
     groupbyfields = ["sender"]
-    gbyDesc = GroupBySig(groupbyfields, ops, fields)
+    gbyDesc = GroupBySig(emails.schema(), groupbyfields, ops, fields)
     groupedEmails = emails.groupby(gbyDesc)
     return groupedEmails
 
@@ -182,7 +182,7 @@ def buildImageAggPlan(datasetId):
     ops = ["count"]
     fields = ["breed"]
     groupbyfields = ["breed"]
-    gbyDesc = GroupBySig(groupbyfields, ops, fields)
+    gbyDesc = GroupBySig(dogImages, groupbyfields, ops, fields)
     groupedDogImages = dogImages.groupby(gbyDesc)
     return groupedDogImages
 


### PR DESCRIPTION
Add code to support group bys.  This should supersede the existing aggregation operator, but I have not removed that code in this pull request.

I have added several examples of aggregation to simpleDemo.py.  For example:

```
def enronGbyPlan(datasetId):
    emails = pz.Dataset(datasetId, schema=Email)
    ops = ["count"]
    fields = ["sender"]
    groupbyfields = ["sender"]
    gbyDesc = GroupBySig(groupbyfields, ops, fields)
    groupedEmails = emails.groupby(gbyDesc)
    return groupedEmails
```

Here we count emails by sender.  The GroupBySig class is a class that encapsulates the signature of the group by and contains utility functions for getting the output schema of the group by operation.

Note passing in an empty (not null) array for the groupbyfields variable here would result in performing a ungrouped aggregate.

Currently only count and average are supported but adding new aggregates should be straightforward.  A useful extension might be to add an LLM-based aggregate where the group of records is sent to an LLM to perform the aggregation over them.
